### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - scala: SCALA_NATIVE
       jdk: oraclejdk8
       before_install:
-      - curl https://raw.githubusercontent.com/scala-native/scala-native/2941b8ba26de42/bin/travis_setup.sh | bash -
+      - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -
       script:
       - sbt pprintNative/test
 


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.