### PR TITLE
fix warnings. use '\'' instead of '''

### DIFF
--- a/pprint/shared/src/main/scala/pprint/Walker.scala
+++ b/pprint/shared/src/main/scala/pprint/Walker.scala
@@ -47,9 +47,9 @@ abstract class Walker{
       case null => Tree.Literal("null")
       case x: Char =>
         val sb = new StringBuilder
-        sb.append(''')
+        sb.append('\'')
         Util.escapeChar(x, sb)
-        sb.append(''')
+        sb.append('\'')
         Tree.Literal(sb.toString)
       case x: Byte => Tree.Literal(x.toString)
       case x: Short => Tree.Literal(x.toString)


### PR DESCRIPTION
```
Welcome to Scala 2.12.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_192).
Type in expressions for evaluation. Or try :help.

scala> '''
<console>:12: warning: deprecated syntax for character literal (use '\'' for single quote)
       '''
       ^
res0: Char = '
```

```
Welcome to Scala 2.13.0-M5 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_192).
Type in expressions for evaluation. Or try :help.

scala> '''
       ^
       error: empty character literal (use '\'' for single quote)
         ^
       error: unclosed character literal (or use " not ' for string literal)
```