### PR TITLE
[WIP] Include field names in rendering of Product (Scala 2.13 only)

### DIFF
--- a/pprint/src-2.11/pprint/ProductSupport.scala
+++ b/pprint/src-2.11/pprint/ProductSupport.scala
@@ -1,0 +1,11 @@
+package pprint
+
+object ProductSupport {
+
+  def treeifyProductElements(
+    x: Product,
+    walker: Walker
+  ): Iterator[Tree] =
+    x.productIterator.map(x => walker.treeify(x))
+
+}

--- a/pprint/src-2.12/pprint/ProductSupport.scala
+++ b/pprint/src-2.12/pprint/ProductSupport.scala
@@ -1,0 +1,11 @@
+package pprint
+
+object ProductSupport {
+
+  def treeifyProductElements(
+    x: Product,
+    walker: Walker
+  ): Iterator[Tree] =
+    x.productIterator.map(x => walker.treeify(x))
+
+}

--- a/pprint/src-2.13/pprint/ProductSupport.scala
+++ b/pprint/src-2.13/pprint/ProductSupport.scala
@@ -1,0 +1,18 @@
+package pprint
+
+object ProductSupport {
+
+  def treeifyProductElements(
+    x: Product,
+    walker: Walker
+  ): Iterator[Tree] = {
+    x.productElementNames
+      .zipWithIndex
+      .map {
+        case (name, i) =>
+          val elem = x.productElement(i)
+          Tree.KeyValue(name, walker.treeify(elem))
+      }
+  }
+
+}

--- a/pprint/src/pprint/Renderer.scala
+++ b/pprint/src/pprint/Renderer.scala
@@ -135,6 +135,10 @@ class Renderer(maxWidth: Int,
 
     case t: Tree.Literal => Result.fromString(colorLiteral(t.body))
 
+    case Tree.KeyValue(k, v) =>
+      Result.fromString(s"$k = ")
+        .flatMap((_, _) => rec(v, leftOffset, indentCount))
+
   }
 }
 

--- a/pprint/src/pprint/Walker.scala
+++ b/pprint/src/pprint/Walker.scala
@@ -26,6 +26,11 @@ object Tree{
   }
 
   /**
+    * x = y
+    */
+  case class KeyValue(key: String, value: Tree) extends Tree
+
+  /**
     * xyz
     */
   case class Lazy(body0: Ctx => Iterator[String]) extends Tree
@@ -102,7 +107,7 @@ abstract class Walker{
             Tree.Apply("", x.productIterator.map(x => treeify(x)))
 
           case _ =>
-            Tree.Apply(x.productPrefix, x.productIterator.map(x => treeify(x)))
+            Tree.Apply(x.productPrefix, ProductSupport.treeifyProductElements(x, this))
         }
 
       case x => Tree.Lazy(ctx => Iterator(x.toString))


### PR DESCRIPTION
As requested in #4.

This is only available in Scala 2.13 because it makes use of productElementNames. The behaviour is unchanged in Scala 2.11/2.12.

Unfortunately it's a bincompat-breaking change because it extends the `Tree` ADT. Not sure how amenable you are to that.

The tests need to be updated because pprint's output is now different in Scala 2.12 vs 2.13. @lihaoyi do you have any preference regarding how I handle different Scala versions in the tests?

* I could have separate `test/src`, `test/src-2.11`, `test/src-2.12` and `test/src-2.13` directories (I assume Mill supports that convention for test directories as well), but that might require a bit of refactoring of the tests if we want to avoid a lot of duplication.
* Or I could add conditionals in the test code, along the lines of `if (scala213) { assert(...) } else { ... }`, but that could get pretty ugly.

EDIT: Sorry, this was supposed to be draft PR. Apparently it's not possible to change a normal PR to a draft.