### PR TITLE
Fix printing of annotated type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ target/
 project/.sbtserver
 tags
 nohup.out
+.bloop/
+.metals/
+.vscode/

--- a/pprint/src-0/TPrintImpl.scala
+++ b/pprint/src-0/TPrintImpl.scala
@@ -105,7 +105,9 @@ object TPrintLowPri{
             Expr("type " + name) + printBounds(cfg)(lo, hi) + rec0(cfg)(tpe)
         }.mkStringExpr("; ")
         pre + (if(refinements.isEmpty) '{ "" } else Expr("{") + defs + Expr("}"))
-      case _ =>
+      case AnnotatedType(parent, annot) =>
+        rec0(cfg)(parent, end)
+      case _=>
         Expr(t.show)
     }
     '{

--- a/pprint/test/src-0/test/src/pprint/TPrintTests.scala
+++ b/pprint/test/src-0/test/src/pprint/TPrintTests.scala
@@ -29,6 +29,10 @@ object TPrintTests extends TestSuite{
         check[java.lang.String]("String")
         check[Int]("Int")
 
+
+        val a = List(1,2,3).tail
+        checkVal("List[Int]", a)
+
         check[scala.Int]("Int")
         def t[T] = check[T]("T")
         t


### PR DESCRIPTION
Previously with an expression like:
```
val a = List(1,2,3).tail
checkVal("List[Int]", a)
```
It would print:
`res1: List[scala.collection.immutable.List[scala.Int @scala.annotation.unchecked.uncheckedVariance]] `

This fixes it to show `List[Int[`