### PR TITLE
Update Scala Native to 0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: scala
-
-sudo: required
-
-dist: trusty
-
+os: linux
+dist: bionic
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
-  - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
-  - ./mill __.test.test
+  - ./mill -i __.test

--- a/mill
+++ b/mill
@@ -3,7 +3,7 @@
 # This is a wrapper script, that automatically download mill from GitHub release pages
 # You can give the required mill version with MILL_VERSION env variable
 # If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
-DEFAULT_MILL_VERSION=0.8.0-13-105f53
+DEFAULT_MILL_VERSION=0.9.4-29-9d1d6f
 
 set -e
 

--- a/pprint/src-2/TPrintImpl.scala
+++ b/pprint/src-2/TPrintImpl.scala
@@ -195,7 +195,7 @@ object TPrintLowPri{
       case ConstantType(value) =>
         q"$value.toString"
     }
-    lazy val cfgSym = c.freshName[TermName]("cfg")
+    lazy val cfgSym = c.freshName[TermName](TermName("cfg"))
     val res = c.Expr[TPrint[T]](q"""_root_.pprint.TPrint.lambda{
       ($cfgSym: _root_.pprint.TPrintColors) =>
         ${rec0(tpe, end = true)}

--- a/pprint/src-3/TPrintImpl.scala
+++ b/pprint/src-3/TPrintImpl.scala
@@ -1,7 +1,7 @@
 package pprint
 
 trait TPrintLowPri{
-  inline given default[T] as TPrint[T] = ${ TPrintLowPri.typePrintImpl[T] }
+  inline given default[T]: TPrint[T] = ${ TPrintLowPri.typePrintImpl[T] }
 }
 
 object TPrintLowPri{

--- a/pprint/src/pprint/Walker.scala
+++ b/pprint/src/pprint/Walker.scala
@@ -67,7 +67,7 @@ abstract class Walker{
         if (x.exists(c => c == '\n' || c == '\r')) Tree.Literal("\"\"\"" + x + "\"\"\"")
         else Tree.Literal(Util.literalize(x))
 
-      case x: Symbol => Tree.Literal(x.toString)
+      case x: Symbol => Tree.Literal("'" + x.name)
 
       case x: scala.collection.Map[_, _] =>
         Tree.Apply(


### PR DESCRIPTION
There was a breaking change in the macros api going from Scala 2.13.2 to 2.13.3.
It needs some investigation..