### PR TITLE
chore: bump mill version to 1.0.6

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.0
+//| mill-version: 1.0.6
 //| mvnDeps:
 //| - com.github.lolgab::mill-mima_mill1:0.2.0
 import mill._, scalalib._, scalajslib._, scalanativelib._, publish._


### PR DESCRIPTION
To be able to still work with the Scala 3 CB, we need to bump the mill-version to 1.0.6