### PR TITLE
Render common subclasses of `Map`/`Seq`/`Set`s as the common factory object name

### DIFF
--- a/pprint/src/pprint/Walker.scala
+++ b/pprint/src/pprint/Walker.scala
@@ -108,7 +108,6 @@ abstract class Walker{
 
       case x: Array[_] => Tree.Apply("Array", x.iterator.map(x => treeify(x, escapeUnicode, showFieldNames)))
 
-
       case x: Product =>
         val className = x.getClass.getName
         if (x.productArity == 0) Tree.Lazy(ctx => Iterator(x.toString))


### PR DESCRIPTION
Otherwise you end up rendering them as `ArraySeq` or `HashMap` or `HashSet`, which isn't valid code without additional imports. This is surprising when the value was created via `Seq`, `Map`, or `Set`. This is especially problematic combined with uTest's https://github.com/com-lihaoyi/utest?tab=readme-ov-file#assertgoldenliteral

Tested manually