### PR TITLE
Special-case StringBuilder and lazy iterables

### DIFF
--- a/pprint/src/pprint/Walker.scala
+++ b/pprint/src/pprint/Walker.scala
@@ -48,6 +48,11 @@ object Tree{
 
 abstract class Walker{
   val tuplePrefix = "scala.Tuple"
+  val lazyClassNames = Set(
+    "scala.collection.immutable.Stream$Cons",
+    "scala.collection.immutable.LazyList",
+    "scala.collection.immutable.LazyListIterable"
+  )
 
   def additionalHandlers: PartialFunction[Any, Tree]
   def treeify(x: Any, escapeUnicode: Boolean, showFieldNames: Boolean): Tree = additionalHandlers.lift(x).getOrElse{
@@ -72,6 +77,8 @@ abstract class Walker{
         if (x.exists(c => c == '\n' || c == '\r')) Tree.Literal("\"\"\"" + x + "\"\"\"")
         else Tree.Literal(Util.literalize(x, escapeUnicode))
 
+      case x: StringBuilder => treeify(x.toString, escapeUnicode, showFieldNames)
+
       case x: Symbol => Tree.Literal("'" + x.name)
 
       case x: scala.collection.Map[_, _] =>
@@ -86,6 +93,12 @@ abstract class Walker{
             Seq(Tree.Infix(treeify(k, escapeUnicode, showFieldNames), "->", treeify(v, escapeUnicode, showFieldNames)))
           }
         )
+
+      // Do not force Streams and LazyLists to be computed.
+      // Unfortunately, they do not leak lazy/eagerness by design, so we cannot simply ask "are you still lazy?".
+      // So we check their toString.
+      case x: Iterable[_] if lazyClassNames(x.getClass.getName) && x.toString.contains("<not computed>") =>
+        Tree.Literal(x.toString)
 
       case x: Iterable[_] =>
         Tree.Apply(

--- a/pprint/test/src-2.13/test/pprint/fields/VerticalTests.scala
+++ b/pprint/test/src-2.13/test/pprint/fields/VerticalTests.scala
@@ -437,19 +437,6 @@ object VerticalTests extends TestSuite{
           )
         }
       }
-
-      test("stream"){
-        val Check = new Check(height = 5)
-        Check(
-          Stream.continually("foo"),
-          """Stream(
-            |  "foo",
-            |  "foo",
-            |  "foo",
-            |...
-          """.stripMargin
-        )
-      }
     }
 
     test("wrappedLines"){

--- a/pprint/test/src-2/test/pprint/HorizontalVersionSpecificTests.scala
+++ b/pprint/test/src-2/test/pprint/HorizontalVersionSpecificTests.scala
@@ -6,8 +6,6 @@ import scala.collection.{immutable => imm, mutable}
 object HorizontalVersionSpecificTests extends TestSuite{
   val Check = new Check(9999)
   val tests = TestSuite{
-    // Streams are hard-coded to always display vertically, in order
-    // to make streaming pretty-printing sane
     test("Stream") - Check(
       Stream('omg, 'wtf, 'bbq),
       """Stream('omg, 'wtf, 'bbq)"""

--- a/pprint/test/src-3/test/src/pprint/HorizontalVersionSpecificTests.scala
+++ b/pprint/test/src-3/test/src/pprint/HorizontalVersionSpecificTests.scala
@@ -8,13 +8,17 @@ object HorizontalVersionSpecificTests extends TestSuite{
   val Check = new Check(100, 9999, false, false)
 
   val tests = TestSuite{
-    // Streams are hard-coded to always display vertically, in order
-    // to make streaming pretty-printing sane
-    test("LazyList") - Check(
-      LazyList("omg", "wtf", "bbq"),
-      """LazyList("omg", "wtf", "bbq")"""
-    )
-
+    // Only show LazyList contents if they've been computed already
+    test("LazyList") {
+      test - Check(
+        { val l = LazyList("omg", "wtf", "bbq"); l.toArray; l },
+        """LazyList("omg", "wtf", "bbq")"""
+      )
+      test - Check(
+        "omg" #:: LazyList.empty,
+        """LazyList(<not computed>)"""
+      )
+    }
   }
 
 

--- a/pprint/test/src/test/pprint/HorizontalTests.scala
+++ b/pprint/test/src/test/pprint/HorizontalTests.scala
@@ -115,7 +115,10 @@ object HorizontalTests extends TestSuite{
           """WrappedArray("omg", "wtf", "bbq")"""
         )
 
-
+        test("stream") - Check(
+          Stream.continually("foo"),
+          """Stream(foo, <not computed>)"""
+        )
 
         test("Iterable") - Check(Iterable("omg", "wtf", "bbq"), """List("omg", "wtf", "bbq")""")
         test("Set") - Check(Set("omg"), """Set("omg")""")
@@ -145,6 +148,11 @@ object HorizontalTests extends TestSuite{
           imm.SortedMap("key" -> "v", "key2" -> "v2"),
           """Map("key" -> "v", "key2" -> "v2")""",
           """TreeMap("key" -> "v", "key2" -> "v2")"""
+        )
+
+        test("StringBuilder") - Check(
+          mutable.StringBuilder("example"),
+          """ "example" """
         )
       }
 

--- a/pprint/test/src/test/pprint/VerticalTests.scala
+++ b/pprint/test/src/test/pprint/VerticalTests.scala
@@ -369,19 +369,6 @@ object VerticalTests extends TestSuite{
           )
         }
       }
-
-      test("stream"){
-        val Check = new Check(height = 5)
-        Check(
-          Stream.continually("foo"),
-          """Stream(
-            |  "foo",
-            |  "foo",
-            |  "foo",
-            |...
-          """.stripMargin
-        )
-      }
     }
 
     test("wrappedLines"){


### PR DESCRIPTION
Related to https://github.com/scala/scala3/issues/25116

StringBuilder is probably not controversial, it's weird to display it as an iterable of individual characters. (I noticed this because we have a scala3-repl test that checks for this, which used to be effectively disabled for bad infra-related reasons)

Lazy iterables are a bit more controversial... there's no easy way to tell whether an iterable is lazy, and surprisingly even something like `LazyList("a", "b", "c")` is technically lazy from `LazyList`'s perspective (i.e., its `toString` is `LazyList(<not computed>)`). So we check `toString` for the magic `<not computed>` string. Not great, but I think always evaluating lazy iterables is worse.